### PR TITLE
Implement stream_orders_by_order_id for issue #230

### DIFF
--- a/src/services/Brokerage/brokerage_service.py
+++ b/src/services/Brokerage/brokerage_service.py
@@ -740,33 +740,61 @@ class BrokerageService:
         else:
             return Positions.model_validate(response)
 
-    # NOTE: This method is a placeholder for future implementation
-    # async def stream_orders(self, account_ids: str) -> Any:
-    #     """
-    #     Streams orders for the given Accounts.
-    #
-    #     Args:
-    #         account_ids: List of valid Account IDs in comma separated format (e.g. "61999124,68910124").
-    #                     1 to 25 Account IDs can be specified. Recommended batch size is 10.
-    #
-    #     Returns:
-    #         An EventEmitter object that emits order events.
-    #
-    #     Raises:
-    #         ValueError: If more than 25 account IDs are specified
-    #         Exception: If the request fails due to network issues or API errors
-    #     """
-    #     # Validate maximum accounts
-    #     if len(account_ids.split(",")) > 25:
-    #         raise ValueError("Maximum of 25 accounts allowed per request")
-    #
-    #     response = await self.http_client.get(f"/v3/brokerage/accounts/{account_ids}/streamorders")
-    #
-    #     # Handle both direct response and response with data attribute (for tests)
-    #     if hasattr(response, "data"):
-    #         return EventEmitter.model_validate(response.data)
-    #     else:
-    #         return EventEmitter.model_validate(response)
+    async def stream_orders_by_order_id(self, account_ids: str, order_ids: str) -> WebSocketStream:
+        """
+        Streams specific open orders for the given account IDs and order IDs.
+
+        This endpoint establishes a real-time stream for updates on specific orders.
+        Updates can include status changes, fills, cancellations, etc.
+
+        Args:
+            account_ids: Comma-separated string of account IDs (e.g., "123456,789012").
+                         Maximum 25 account IDs.
+            order_ids: Comma-separated string of order IDs (e.g., "ORDER1,ORDER2").
+                       Maximum 50 order IDs (assumption, needs verification based on API docs).
+
+        Returns:
+            A WebSocketStream object that asynchronously yields order update messages.
+            Each message is typically a JSON object representing the order state.
+
+        Raises:
+            ValueError: If the number of provided account IDs or order IDs exceeds limits.
+            Exception: If the stream connection fails or parameters are invalid.
+
+        Example:
+            ```python
+            # Assuming brokerage_service is an initialized BrokerageService instance
+            order_stream = await brokerage_service.stream_orders_by_order_id(
+                account_ids="YOUR_ACCOUNT_ID",
+                order_ids="YOUR_ORDER_ID_1,YOUR_ORDER_ID_2"
+            )
+
+            async for order_update in order_stream:
+                print(f"Received order update: {order_update}")
+                # Process the update (e.g., update local state, trigger actions)
+            ```
+        """
+        # Convert comma-separated strings to lists
+        account_id_list = account_ids.split(",")
+        order_id_list = order_ids.split(",")
+
+        # Basic validation for the number of IDs
+        if len(account_id_list) > 25:
+            raise ValueError("Maximum number of account IDs (25) exceeded.")
+        # Assuming a limit of 50 for order IDs, based on historical orders endpoint pattern
+        if len(order_id_list) > 50:
+            raise ValueError("Maximum number of order IDs (50) exceeded.")
+
+        request_payload = {
+            "Orders": {
+                "AccountIDs": account_id_list,
+                "OrderIDs": order_id_list,
+            }
+        }
+        # Assuming the stream manager handles the underlying WebSocket connection
+        # and message parsing based on the payload structure.
+        # Return the awaitable stream object
+        return await self.stream_manager.create_stream(request_payload)
 
     async def stream_orders(self, account_ids: str) -> WebSocketStream:
         """

--- a/tests/services/Brokerage/test_stream_orders_by_orderid.py
+++ b/tests/services/Brokerage/test_stream_orders_by_orderid.py
@@ -1,0 +1,88 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from src.services.Brokerage.brokerage_service import BrokerageService
+from src.streaming.stream_manager import StreamManager
+from src.client.http_client import HttpClient
+from src.utils.stream_manager import WebSocketStream
+
+
+@pytest.fixture
+def mock_brokerage_service():
+    """Fixture to create a BrokerageService with mocked dependencies."""
+    mock_http_client = AsyncMock(spec=HttpClient)
+    mock_stream_manager = AsyncMock(spec=StreamManager)
+    # Mock the create_stream method to return an AsyncMock that can be awaited
+    mock_stream_manager.create_stream = AsyncMock(return_value=AsyncMock(spec=WebSocketStream))
+    service = BrokerageService(mock_http_client, mock_stream_manager)
+    return service, mock_stream_manager
+
+
+@pytest.mark.asyncio
+async def test_stream_orders_by_order_id_success(mock_brokerage_service):
+    """Test successful call to stream_orders_by_order_id."""
+    # Arrange
+    brokerage_service, mock_stream_manager = mock_brokerage_service
+    account_ids = "123456,789012"
+    order_ids = "ORDER1,ORDER2"
+    expected_payload = {
+        "Orders": {
+            "AccountIDs": ["123456", "789012"],
+            "OrderIDs": ["ORDER1", "ORDER2"],
+        }
+    }
+
+    # Act
+    stream = await brokerage_service.stream_orders_by_order_id(account_ids, order_ids)
+
+    # Assert
+    mock_stream_manager.create_stream.assert_called_once_with(expected_payload)
+    assert isinstance(stream, AsyncMock)  # Check if it returned the mocked stream object
+
+
+@pytest.mark.asyncio
+async def test_stream_orders_by_order_id_max_accounts_exceeded(mock_brokerage_service):
+    """Test ValueError when max account IDs are exceeded."""
+    # Arrange
+    brokerage_service, _ = mock_brokerage_service
+    account_ids = ",".join([f"ACC{i}" for i in range(26)])  # 26 account IDs
+    order_ids = "ORDER1"
+
+    # Act & Assert
+    with pytest.raises(ValueError, match=r"Maximum number of account IDs \(25\) exceeded."):
+        await brokerage_service.stream_orders_by_order_id(account_ids, order_ids)
+
+
+@pytest.mark.asyncio
+async def test_stream_orders_by_order_id_max_orders_exceeded(mock_brokerage_service):
+    """Test ValueError when max order IDs are exceeded."""
+    # Arrange
+    brokerage_service, _ = mock_brokerage_service
+    account_ids = "123456"
+    order_ids = ",".join([f"ORD{i}" for i in range(51)])  # 51 order IDs
+
+    # Act & Assert
+    with pytest.raises(ValueError, match=r"Maximum number of order IDs \(50\) exceeded."):
+        await brokerage_service.stream_orders_by_order_id(account_ids, order_ids)
+
+
+@pytest.mark.asyncio
+async def test_stream_orders_by_order_id_single_ids(mock_brokerage_service):
+    """Test successful call with single account and order ID."""
+    # Arrange
+    brokerage_service, mock_stream_manager = mock_brokerage_service
+    account_ids = "987654"
+    order_ids = "SINGLEORDER"
+    expected_payload = {
+        "Orders": {
+            "AccountIDs": ["987654"],
+            "OrderIDs": ["SINGLEORDER"],
+        }
+    }
+
+    # Act
+    stream = await brokerage_service.stream_orders_by_order_id(account_ids, order_ids)
+
+    # Assert
+    mock_stream_manager.create_stream.assert_called_once_with(expected_payload)
+    assert isinstance(stream, AsyncMock)


### PR DESCRIPTION
# PR: Implement Brokerage Service: StreamOrdersByOrderID

## Overview
This PR implements the `stream_orders_by_order_id` method in the `BrokerageService` class, fulfilling the requirements of issue #230. This allows users to establish a real-time stream for updates on specific orders within specified accounts.

## What was implemented
- Added the `stream_orders_by_order_id(account_ids: str, order_ids: str)` asynchronous method to `BrokerageService`.
- Input validation for maximum number of account IDs (25) and order IDs (50, based on assumption from similar endpoints).
- Calls `StreamManager.create_stream` with the appropriate payload structure to initiate the WebSocket stream.
- Created a new dedicated test file `tests/services/Brokerage/test_stream_orders_by_orderid.py`.
- Implemented unit tests using `pytest` and `unittest.mock` covering:
    - Successful stream creation and payload verification.
    - Validation errors for exceeding maximum account IDs.
    - Validation errors for exceeding maximum order IDs.
    - Successful call with single account/order IDs.

## Implementation details

### Design Approach
- The method integrates with the existing `StreamManager` by formatting the request payload (`{\"Orders\": {\"AccountIDs\": [...], \"OrderIDs\": [...]}}`) and calling `create_stream`.
- Input validation is performed upfront to prevent invalid requests to the `StreamManager`.
- The method directly returns the `WebSocketStream` object provided by the `StreamManager`, allowing the caller to iterate over incoming messages asynchronously.
- Follows the established pattern for service methods within the `BrokerageService` class.

### Files Changed
| File | Changes |
|------|---------|
| `src/services/Brokerage/brokerage_service.py` | Added the `stream_orders_by_order_id` method, including docstrings and input validation. Added `await` to the `create_stream` call. |
| `tests/services/Brokerage/test_stream_orders_by_orderid.py` | Created new test file with fixtures and tests for `stream_orders_by_order_id`. Fixed minor syntax warnings. |

### Architecture Flow
```mermaid
sequenceDiagram
    participant Client
    participant BrokerageService
    participant StreamManager
    participant TradeStationAPI (WebSocket)

    Client->>+BrokerageService: stream_orders_by_order_id(account_ids, order_ids)
    BrokerageService->>BrokerageService: Validate account_ids, order_ids counts
    BrokerageService->>+StreamManager: create_stream(payload)
    StreamManager->>+TradeStationAPI (WebSocket): Establish Connection & Send Subscription Request (with payload)
    TradeStationAPI (WebSocket)-->>-StreamManager: Connection Acknowledged
    StreamManager-->>-BrokerageService: Returns WebSocketStream object
    BrokerageService-->>-Client: Returns WebSocketStream object

    loop Real-time Updates
        TradeStationAPI (WebSocket)-->>StreamManager: Sends Order Update Message
        StreamManager->>WebSocketStream: Yields message
        Client->>WebSocketStream: Receives message (via async for loop)
    end
```

## Testing
- Unit tests were implemented using `pytest` and `unittest.mock.AsyncMock`.
- `StreamManager` and `HttpClient` were mocked to isolate the `BrokerageService` logic.
- `mock_stream_manager.create_stream` was mocked to verify it's called with the correct payload and to simulate the return of a stream object.
- Tests cover:
    - Correct payload construction for `create_stream`.
    - `ValueError` raised for > 25 account IDs.
    - `ValueError` raised for > 50 order IDs.
    - Handling of single and multiple IDs in input strings.

## How to test the changes
1. Run the automated unit tests:
   ```bash
   poetry run pytest tests/services/Brokerage/test_stream_orders_by_orderid.py -v
   ```
2. Manual testing (requires valid credentials and active orders):
   ```python
   import asyncio
   from tradestation import TradeStation
   from dotenv import load_dotenv
   import os

   load_dotenv() # Load credentials from .env file

   async def main():
       ts = TradeStation(
           client_id=os.getenv("CLIENT_ID"),
           client_secret=os.getenv("CLIENT_SECRET"),
           paper_trade=True # Or False for live trading
       )
       await ts.login(refresh_token=os.getenv("REFRESH_TOKEN")) # Use your refresh token

       # Replace with your actual account ID(s) and open order ID(s)
       account_ids = "YOUR_ACCOUNT_ID"
       order_ids = "YOUR_ORDER_ID_1,YOUR_ORDER_ID_2"

       try:
           print(f"Attempting to stream orders {order_ids} for account(s) {account_ids}...")
           order_stream = await ts.brokerage.stream_orders_by_order_id(
               account_ids=account_ids,
               order_ids=order_ids
           )
           print("Stream established. Waiting for updates...")

           async for update in order_stream:
               print(f"Received order update: {update}")
               # Add logic to stop after a few updates or a timeout for testing
               # break # Example: Stop after first update

       except Exception as e:
           print(f"An error occurred: {e}")
       finally:
           # Ensure graceful shutdown if needed (depends on StreamManager implementation)
           pass

   if __name__ == "__main__":
       asyncio.run(main())
   ```

## Knowledge Base Updates
- No updates to `CONTINUOUS-SELF-LEARNING.md` for this issue.

Closes #230 