### PR TITLE
Implement StreamPositions for issue #231

### DIFF
--- a/tests/services/Brokerage/test_stream_orders_by_orderid.py
+++ b/tests/services/Brokerage/test_stream_orders_by_orderid.py
@@ -25,18 +25,16 @@ async def test_stream_orders_by_order_id_success(mock_brokerage_service):
     brokerage_service, mock_stream_manager = mock_brokerage_service
     account_ids = "123456,789012"
     order_ids = "ORDER1,ORDER2"
-    expected_payload = {
-        "Orders": {
-            "AccountIDs": ["123456", "789012"],
-            "OrderIDs": ["ORDER1", "ORDER2"],
-        }
-    }
 
     # Act
     stream = await brokerage_service.stream_orders_by_order_id(account_ids, order_ids)
 
     # Assert
-    mock_stream_manager.create_stream.assert_called_once_with(expected_payload)
+    mock_stream_manager.create_stream.assert_called_once_with(
+        f"/v3/brokerage/stream/accounts/{account_ids}/orders/{order_ids}",
+        {},
+        {"headers": {"Accept": "application/vnd.tradestation.streams.v3+json"}},
+    )
     assert isinstance(stream, AsyncMock)  # Check if it returned the mocked stream object
 
 
@@ -73,16 +71,14 @@ async def test_stream_orders_by_order_id_single_ids(mock_brokerage_service):
     brokerage_service, mock_stream_manager = mock_brokerage_service
     account_ids = "987654"
     order_ids = "SINGLEORDER"
-    expected_payload = {
-        "Orders": {
-            "AccountIDs": ["987654"],
-            "OrderIDs": ["SINGLEORDER"],
-        }
-    }
 
     # Act
     stream = await brokerage_service.stream_orders_by_order_id(account_ids, order_ids)
 
     # Assert
-    mock_stream_manager.create_stream.assert_called_once_with(expected_payload)
+    mock_stream_manager.create_stream.assert_called_once_with(
+        f"/v3/brokerage/stream/accounts/{account_ids}/orders/{order_ids}",
+        {},
+        {"headers": {"Accept": "application/vnd.tradestation.streams.v3+json"}},
+    )
     assert isinstance(stream, AsyncMock)

--- a/tests/services/Brokerage/test_stream_positions.py
+++ b/tests/services/Brokerage/test_stream_positions.py
@@ -1,0 +1,147 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.client.http_client import HttpClient
+from src.services.Brokerage.brokerage_service import BrokerageService
+from src.streaming.stream_manager import StreamManager
+from src.utils.stream_manager import WebSocketStream
+
+
+@pytest.fixture
+def http_client_mock():
+    """Create a mock HTTP client for testing"""
+    mock = AsyncMock(spec=HttpClient)
+    return mock
+
+
+@pytest.fixture
+def stream_manager_mock():
+    """Create a mock StreamManager for testing"""
+    mock = MagicMock(spec=StreamManager)
+    # Configure the create_stream method to return an AsyncMock WebSocketStream
+    mock.create_stream = AsyncMock()
+    return mock
+
+
+@pytest.fixture
+def mock_stream():
+    """Create a mock WebSocketStream for testing"""
+    mock = MagicMock(spec=WebSocketStream)
+    return mock
+
+
+@pytest.fixture
+def brokerage_service(http_client_mock, stream_manager_mock):
+    """Create a BrokerageService instance with mock dependencies"""
+    return BrokerageService(http_client_mock, stream_manager_mock)
+
+
+class TestStreamPositions:
+    """Tests for the stream_positions method in BrokerageService"""
+
+    @pytest.mark.asyncio
+    async def test_stream_positions_for_single_account(
+        self, brokerage_service, stream_manager_mock, mock_stream
+    ):
+        """Test streaming positions for a single account"""
+        # Configure the mock stream manager to return our mock stream
+        stream_manager_mock.create_stream.return_value = mock_stream
+
+        # Call the method
+        result = await brokerage_service.stream_positions("123456")
+
+        # Verify the stream manager was called correctly
+        stream_manager_mock.create_stream.assert_called_once_with(
+            "/v3/brokerage/stream/accounts/123456/positions",
+            {},
+            {"headers": {"Accept": "application/vnd.tradestation.streams.v3+json"}},
+        )
+
+        # Verify the result is the mock stream
+        assert result == mock_stream
+
+    @pytest.mark.asyncio
+    async def test_stream_positions_for_multiple_accounts(
+        self, brokerage_service, stream_manager_mock, mock_stream
+    ):
+        """Test streaming positions for multiple accounts"""
+        # Configure the mock stream manager to return our mock stream
+        stream_manager_mock.create_stream.return_value = mock_stream
+
+        # Call the method with multiple accounts
+        result = await brokerage_service.stream_positions("123456,789012")
+
+        # Verify the stream manager was called correctly with multiple accounts
+        stream_manager_mock.create_stream.assert_called_once_with(
+            "/v3/brokerage/stream/accounts/123456,789012/positions",
+            {},
+            {"headers": {"Accept": "application/vnd.tradestation.streams.v3+json"}},
+        )
+
+        # Verify the result is the mock stream
+        assert result == mock_stream
+
+    @pytest.mark.asyncio
+    async def test_stream_positions_with_changes_parameter(
+        self, brokerage_service, stream_manager_mock, mock_stream
+    ):
+        """Test streaming positions with changes parameter set to True"""
+        # Configure the mock stream manager to return our mock stream
+        stream_manager_mock.create_stream.return_value = mock_stream
+
+        # Call the method with changes=True
+        result = await brokerage_service.stream_positions("123456", True)
+
+        # Verify the stream manager was called correctly with changes parameter
+        stream_manager_mock.create_stream.assert_called_once_with(
+            "/v3/brokerage/stream/accounts/123456/positions",
+            {"changes": True},
+            {"headers": {"Accept": "application/vnd.tradestation.streams.v3+json"}},
+        )
+
+        # Verify the result is the mock stream
+        assert result == mock_stream
+
+    @pytest.mark.asyncio
+    async def test_stream_positions_with_changes_parameter_false(
+        self, brokerage_service, stream_manager_mock, mock_stream
+    ):
+        """Test streaming positions with changes parameter set to False"""
+        # Configure the mock stream manager to return our mock stream
+        stream_manager_mock.create_stream.return_value = mock_stream
+
+        # Call the method with changes=False
+        result = await brokerage_service.stream_positions("123456", False)
+
+        # Verify the stream manager was called correctly with changes parameter false
+        # Note: We don't include changes=False in the parameters since it's the default
+        stream_manager_mock.create_stream.assert_called_once_with(
+            "/v3/brokerage/stream/accounts/123456/positions",
+            {},
+            {"headers": {"Accept": "application/vnd.tradestation.streams.v3+json"}},
+        )
+
+        # Verify the result is the mock stream
+        assert result == mock_stream
+
+    @pytest.mark.asyncio
+    async def test_stream_positions_with_too_many_accounts(self, brokerage_service):
+        """Test that an error is raised when too many accounts are specified"""
+        # Create a string with 26 comma-separated account IDs (exceeding the limit of 25)
+        too_many_accounts = ",".join([f"ACC{i}" for i in range(1, 27)])
+
+        # Verify that a ValueError is raised
+        with pytest.raises(ValueError, match="Maximum of 25 accounts allowed per request"):
+            await brokerage_service.stream_positions(too_many_accounts)
+
+    @pytest.mark.asyncio
+    async def test_stream_positions_streaming_error(self, brokerage_service, stream_manager_mock):
+        """Test handling of streaming errors"""
+        # Configure the mock stream manager to raise an exception
+        stream_manager_mock.create_stream.side_effect = ConnectionError(
+            "Failed to establish streaming connection"
+        )
+
+        # Verify that the error is propagated
+        with pytest.raises(ConnectionError, match="Failed to establish streaming connection"):
+            await brokerage_service.stream_positions("123456")


### PR DESCRIPTION
# PR: Implement Stream Positions Feature

## Overview
This PR implements the `stream_positions` method in the BrokerageService class to enable real-time streaming of position data for specified accounts, with support for incremental position updates.

## What was implemented
- `stream_positions` method in BrokerageService
- Comprehensive test coverage for the new method
- Fixed inconsistencies in `stream_orders_by_order_id` implementation and tests

## Implementation details

### Design Approach
The implementation follows the established streaming patterns in the codebase:
- Async/await pattern for the streaming API
- Consistent validation for account limits
- Parameter handling for the optional 'changes' flag
- Proper header configuration for stream requests

### Files Changed
| File | Changes |
|------|---------|
| `src/services/Brokerage/brokerage_service.py` | Added `stream_positions` method and fixed `stream_orders_by_order_id` |
| `tests/services/Brokerage/test_stream_positions.py` | Added comprehensive test suite for the new method |
| `tests/services/Brokerage/test_stream_orders_by_orderid.py` | Updated tests to match the fixed implementation |

### Architecture Flow
```mermaid
sequenceDiagram
    Client->>+BrokerageService: stream_positions(account_ids, changes)
    BrokerageService->>BrokerageService: Validate account_ids (max 25)
    BrokerageService->>+StreamManager: create_stream(endpoint, params, headers)
    StreamManager->>+TradeStationAPI: Establish WebSocket connection
    TradeStationAPI-->>-StreamManager: Connection established
    StreamManager-->>-BrokerageService: Return WebSocketStream
    BrokerageService-->>-Client: Return stream
    loop While stream is open
        TradeStationAPI->>Client: Position update events
        TradeStationAPI->>Client: Heartbeat events
        TradeStationAPI->>Client: Status events
    end
```

## Testing
- Unit tests cover successful API responses for single and multiple accounts
- Tests for optional 'changes' parameter in both true and false states
- Error condition tests for account validation
- Tests for streaming connection errors
- Verified compatibility with existing codebase functionality

## How to test the changes
1. Run the specific test file:
```bash
poetry run pytest tests/services/Brokerage/test_stream_positions.py -v
```

2. For manual testing with valid credentials:
```python
from tradestation import TradeStation

async def main():
    ts = TradeStation()
    # Stream all positions
    stream = await ts.brokerage.stream_positions("YOUR_ACCOUNT_ID")
    async for position in stream:
        print(position)
    
    # Stream position changes only
    stream = await ts.brokerage.stream_positions("YOUR_ACCOUNT_ID", True)
    async for position in stream:
        print(position)

# Run with asyncio.run(main())
```

Closes #231
