### PR TITLE
Implement confirm_group_order method for issue #233

### DIFF
--- a/src/services/OrderExecution/order_execution_service.py
+++ b/src/services/OrderExecution/order_execution_service.py
@@ -6,6 +6,8 @@ from ...ts_types.order_execution import (
     CancelOrderResponse,
     ActivationTriggers,
     Routes,
+    GroupOrderRequest,
+    GroupOrderConfirmationResponse,
 )
 
 
@@ -51,3 +53,38 @@ class OrderExecutionService:
         """
         response = await self.http_client.delete(f"/v3/orderexecution/orders/{order_id}")
         return CancelOrderResponse(**response)
+
+    async def confirm_group_order(
+        self, request: GroupOrderRequest
+    ) -> GroupOrderConfirmationResponse:
+        """
+        Creates an Order Confirmation for a group order without actually placing it.
+        Returns estimated cost and commission information for each order in the group.
+
+        Valid for all account types and the following group types:
+        - OCO (Order Cancels Order): If one order is filled/partially-filled, all others are cancelled
+        - BRK (Bracket): Used to exit positions, combining stop and limit orders
+
+        Note: When a group order is submitted, each sibling order is treated as individual.
+        The system does not validate that each order has the same Quantity, and
+        bracket orders cannot be updated as one transaction (must update each order separately).
+
+        Args:
+            request: The group order request containing type and array of orders
+
+        Returns:
+            Array of estimated cost and commission information for each order
+
+        Raises:
+            Exception: Will raise an error if:
+                - The request is invalid (400)
+                - The request is unauthorized (401)
+                - The request is forbidden (403)
+                - Rate limit is exceeded (429)
+                - Service is unavailable (503)
+                - Gateway timeout (504)
+        """
+        response = await self.http_client.post(
+            "/v3/orderexecution/ordergroupconfirm", request.model_dump(exclude_none=True)
+        )
+        return GroupOrderConfirmationResponse(**response)

--- a/tests/services/OrderExecution/test_confirm_group_order.py
+++ b/tests/services/OrderExecution/test_confirm_group_order.py
@@ -1,0 +1,260 @@
+import pytest
+from src.ts_types.order_execution import (
+    GroupOrderRequest,
+    GroupOrderConfirmationResponse,
+    OrderType,
+    OrderSide,
+    TimeInForce,
+    OrderDuration,
+    OrderRequest,
+)
+
+
+class TestConfirmGroupOrder:
+    """Tests for the confirm_group_order method in OrderExecutionService"""
+
+    @pytest.mark.asyncio
+    async def test_confirm_bracket_order(self, order_execution_service, http_client_mock):
+        """Test confirmation of a bracket order"""
+        # Mock response data
+        mock_response = {
+            "Orders": [
+                {"OrderID": "ORDER123", "Message": "Order confirmed"},
+                {"OrderID": "ORDER124", "Message": "Order confirmed"},
+                {"OrderID": "ORDER125", "Message": "Order confirmed"},
+            ]
+        }
+
+        # Configure mock
+        http_client_mock.post.return_value = mock_response
+
+        # Create request
+        request = GroupOrderRequest(
+            Type="BRK",
+            Orders=[
+                OrderRequest(
+                    AccountID="123456",
+                    Symbol="MSFT",
+                    Quantity="100",
+                    OrderType=OrderType.MARKET,
+                    TradeAction=OrderSide.BUY,
+                    TimeInForce=TimeInForce(Duration=OrderDuration.DAY),
+                    Route="Intelligent",
+                ),
+                OrderRequest(
+                    AccountID="123456",
+                    Symbol="MSFT",
+                    Quantity="100",
+                    OrderType=OrderType.LIMIT,
+                    TradeAction=OrderSide.SELL,
+                    TimeInForce=TimeInForce(Duration=OrderDuration.GTC),
+                    Route="Intelligent",
+                    LimitPrice="160",
+                ),
+                OrderRequest(
+                    AccountID="123456",
+                    Symbol="MSFT",
+                    Quantity="100",
+                    OrderType=OrderType.STOP_MARKET,
+                    TradeAction=OrderSide.SELL,
+                    TimeInForce=TimeInForce(Duration=OrderDuration.GTC),
+                    Route="Intelligent",
+                    StopPrice="145",
+                ),
+            ],
+        )
+
+        # Call the method
+        result = await order_execution_service.confirm_group_order(request)
+
+        # Verify the API was called correctly
+        http_client_mock.post.assert_called_once_with(
+            "/v3/orderexecution/ordergroupconfirm", request.model_dump(exclude_none=True)
+        )
+
+        # Verify the result
+        assert isinstance(result, GroupOrderConfirmationResponse)
+        assert len(result.Orders) == 3
+        assert result.Orders[0].OrderID == "ORDER123"
+        assert result.Orders[0].Message == "Order confirmed"
+        assert result.Orders[1].OrderID == "ORDER124"
+        assert result.Orders[1].Message == "Order confirmed"
+        assert result.Orders[2].OrderID == "ORDER125"
+        assert result.Orders[2].Message == "Order confirmed"
+        assert result.Errors is None
+
+    @pytest.mark.asyncio
+    async def test_confirm_oco_order(self, order_execution_service, http_client_mock):
+        """Test confirmation of an OCO order"""
+        # Mock response data
+        mock_response = {
+            "Orders": [
+                {"OrderID": "ORDER123", "Message": "Order confirmed"},
+                {"OrderID": "ORDER124", "Message": "Order confirmed"},
+            ]
+        }
+
+        # Configure mock
+        http_client_mock.post.return_value = mock_response
+
+        # Create request
+        request = GroupOrderRequest(
+            Type="OCO",
+            Orders=[
+                OrderRequest(
+                    AccountID="123456",
+                    Symbol="MSFT",
+                    Quantity="100",
+                    OrderType=OrderType.LIMIT,
+                    TradeAction=OrderSide.SELL,
+                    TimeInForce=TimeInForce(Duration=OrderDuration.GTC),
+                    Route="Intelligent",
+                    LimitPrice="160",
+                ),
+                OrderRequest(
+                    AccountID="123456",
+                    Symbol="MSFT",
+                    Quantity="100",
+                    OrderType=OrderType.STOP_MARKET,
+                    TradeAction=OrderSide.SELL,
+                    TimeInForce=TimeInForce(Duration=OrderDuration.GTC),
+                    Route="Intelligent",
+                    StopPrice="145",
+                ),
+            ],
+        )
+
+        # Call the method
+        result = await order_execution_service.confirm_group_order(request)
+
+        # Verify the API was called correctly
+        http_client_mock.post.assert_called_once_with(
+            "/v3/orderexecution/ordergroupconfirm", request.model_dump(exclude_none=True)
+        )
+
+        # Verify the result
+        assert isinstance(result, GroupOrderConfirmationResponse)
+        assert len(result.Orders) == 2
+        assert result.Orders[0].OrderID == "ORDER123"
+        assert result.Orders[0].Message == "Order confirmed"
+        assert result.Orders[1].OrderID == "ORDER124"
+        assert result.Orders[1].Message == "Order confirmed"
+        assert result.Errors is None
+
+    @pytest.mark.asyncio
+    async def test_confirm_group_order_validation_errors(
+        self, order_execution_service, http_client_mock
+    ):
+        """Test validation errors when confirming a group order"""
+        # Mock response with errors
+        mock_response = {
+            "Orders": [],
+            "Errors": [
+                {
+                    "OrderID": "ORDER123",
+                    "Error": "INVALID_QUANTITY",
+                    "Message": "Quantity must be positive",
+                }
+            ],
+        }
+
+        # Configure mock
+        http_client_mock.post.return_value = mock_response
+
+        # Create request
+        request = GroupOrderRequest(
+            Type="BRK",
+            Orders=[
+                OrderRequest(
+                    AccountID="123456",
+                    Symbol="MSFT",
+                    Quantity="-100",  # Invalid quantity
+                    OrderType=OrderType.MARKET,
+                    TradeAction=OrderSide.BUY,
+                    TimeInForce=TimeInForce(Duration=OrderDuration.DAY),
+                    Route="Intelligent",
+                )
+            ],
+        )
+
+        # Call the method
+        result = await order_execution_service.confirm_group_order(request)
+
+        # Verify the API was called correctly
+        http_client_mock.post.assert_called_once_with(
+            "/v3/orderexecution/ordergroupconfirm", request.model_dump(exclude_none=True)
+        )
+
+        # Verify the result
+        assert isinstance(result, GroupOrderConfirmationResponse)
+        assert len(result.Orders) == 0
+        assert len(result.Errors) == 1
+        assert result.Errors[0].OrderID == "ORDER123"
+        assert result.Errors[0].Error == "INVALID_QUANTITY"
+        assert result.Errors[0].Message == "Quantity must be positive"
+
+    @pytest.mark.asyncio
+    async def test_confirm_group_order_network_error(
+        self, order_execution_service, http_client_mock
+    ):
+        """Test network error handling when confirming a group order"""
+        # Configure mock to raise exception
+        http_client_mock.post.side_effect = Exception("Network error")
+
+        # Create request
+        request = GroupOrderRequest(
+            Type="BRK",
+            Orders=[
+                OrderRequest(
+                    AccountID="123456",
+                    Symbol="MSFT",
+                    Quantity="100",
+                    OrderType=OrderType.MARKET,
+                    TradeAction=OrderSide.BUY,
+                    TimeInForce=TimeInForce(Duration=OrderDuration.DAY),
+                    Route="Intelligent",
+                )
+            ],
+        )
+
+        # Verify the exception is propagated
+        with pytest.raises(Exception, match="Network error"):
+            await order_execution_service.confirm_group_order(request)
+
+        # Verify the API was called correctly
+        http_client_mock.post.assert_called_once_with(
+            "/v3/orderexecution/ordergroupconfirm", request.model_dump(exclude_none=True)
+        )
+
+    @pytest.mark.asyncio
+    async def test_confirm_group_order_unauthorized(
+        self, order_execution_service, http_client_mock
+    ):
+        """Test unauthorized error handling when confirming a group order"""
+        # Configure mock to raise unauthorized exception
+        http_client_mock.post.side_effect = Exception("Unauthorized")
+
+        # Create request
+        request = GroupOrderRequest(
+            Type="BRK",
+            Orders=[
+                OrderRequest(
+                    AccountID="123456",
+                    Symbol="MSFT",
+                    Quantity="100",
+                    OrderType=OrderType.MARKET,
+                    TradeAction=OrderSide.BUY,
+                    TimeInForce=TimeInForce(Duration=OrderDuration.DAY),
+                    Route="Intelligent",
+                )
+            ],
+        )
+
+        # Verify the exception is propagated
+        with pytest.raises(Exception, match="Unauthorized"):
+            await order_execution_service.confirm_group_order(request)
+
+        # Verify the API was called correctly
+        http_client_mock.post.assert_called_once_with(
+            "/v3/orderexecution/ordergroupconfirm", request.model_dump(exclude_none=True)
+        )


### PR DESCRIPTION
# PR: Implement ConfirmGroupOrder for Order Execution Service

## Overview
This PR implements the `confirm_group_order` method in the OrderExecutionService class, allowing users to confirm group orders without actually placing them.

## What was implemented
- `confirm_group_order` method in OrderExecutionService
- Comprehensive unit tests for the method
- Support for both BRK (Bracket) and OCO (Order Cancels Order) group types
- Error handling for validation errors and API failures

## Implementation details

### Design Approach
The implementation follows the repository pattern with clean separation between:
- Public API method in OrderExecutionService
- Data transformation using Pydantic models
- Error handling

### Files Changed
| File | Changes |
|------|---------|
| `src/services/OrderExecution/order_execution_service.py` | Added `confirm_group_order` method |
| `tests/services/OrderExecution/test_confirm_group_order.py` | Added unit tests |

## Testing
- Unit tests cover successful API responses for both BRK and OCO order types
- Mock tests for error conditions (validation errors, API failure)
- Tests for authentication errors

## How to test the changes
```bash
poetry run pytest tests/services/OrderExecution/test_confirm_group_order.py -v
```

Closes #233
