### PR TITLE
Implement confirm_order method for issue #234

### DIFF
--- a/src/services/OrderExecution/order_execution_service.py
+++ b/src/services/OrderExecution/order_execution_service.py
@@ -8,6 +8,8 @@ from ...ts_types.order_execution import (
     Routes,
     GroupOrderRequest,
     GroupOrderConfirmationResponse,
+    OrderRequest,
+    OrderConfirmationResponse,
 )
 
 
@@ -28,6 +30,31 @@ class OrderExecutionService:
         """
         self.http_client = http_client
         self.stream_manager = stream_manager
+
+    async def confirm_order(self, request: OrderRequest) -> OrderConfirmationResponse:
+        """
+        Creates an Order Confirmation without actually placing it.
+        Returns estimated cost and commission information.
+
+        Args:
+            request: The order request to confirm
+
+        Returns:
+            Estimated cost and commission information for the order
+
+        Raises:
+            Exception: Will raise an error if:
+                - The request is invalid (400)
+                - The request is unauthorized (401)
+                - The request is forbidden (403)
+                - Rate limit is exceeded (429)
+                - Service is unavailable (503)
+                - Gateway timeout (504)
+        """
+        response = await self.http_client.post(
+            "/v3/orderexecution/orderconfirm", request.model_dump(exclude_none=True)
+        )
+        return OrderConfirmationResponse(**response)
 
     async def cancel_order(self, order_id: str) -> CancelOrderResponse:
         """

--- a/tests/services/OrderExecution/test_confirm_order.py
+++ b/tests/services/OrderExecution/test_confirm_order.py
@@ -1,0 +1,276 @@
+import pytest
+from unittest.mock import patch
+
+from src.ts_types.order_execution import (
+    OrderRequest,
+    OrderType,
+    OrderSide,
+    TimeInForce,
+    OrderDuration,
+    OrderConfirmationResponse,
+)
+
+
+class TestConfirmOrder:
+    """Tests for the confirm_order method in OrderExecutionService"""
+
+    @pytest.mark.asyncio
+    async def test_confirm_simple_market_order(self, order_execution_service, http_client_mock):
+        """Test confirmation of a simple market order"""
+        # Mock response data
+        mock_response = {
+            "Route": "Intelligent",
+            "Duration": "Day",
+            "Account": "123456",
+            "SummaryMessage": "Buy 100 MSFT Market Day",
+            "EstimatedPrice": "152.05",
+            "EstimatedPriceDisplay": "152.05",
+            "EstimatedCommission": "5.00",
+            "EstimatedCommissionDisplay": "5.00",
+            "InitialMarginDisplay": "7,602.50",
+            "ProductCurrency": "USD",
+            "AccountCurrency": "USD",
+        }
+
+        # Configure mock
+        http_client_mock.post.return_value = mock_response
+
+        # Create request
+        request = OrderRequest(
+            AccountID="123456",
+            Symbol="MSFT",
+            Quantity="100",
+            OrderType=OrderType.MARKET,
+            TradeAction=OrderSide.BUY,
+            TimeInForce=TimeInForce(Duration=OrderDuration.DAY),
+            Route="Intelligent",
+        )
+
+        # Call the method
+        result = await order_execution_service.confirm_order(request)
+
+        # Verify the API was called correctly
+        http_client_mock.post.assert_called_once_with(
+            "/v3/orderexecution/orderconfirm", request.model_dump(exclude_none=True)
+        )
+
+        # Verify the result
+        assert isinstance(result, OrderConfirmationResponse)
+        assert result.Route == "Intelligent"
+        assert result.Duration == "Day"
+        assert result.Account == "123456"
+        assert result.SummaryMessage == "Buy 100 MSFT Market Day"
+        assert result.EstimatedPrice == "152.05"
+        assert result.EstimatedPriceDisplay == "152.05"
+        assert result.EstimatedCommission == "5.00"
+        assert result.EstimatedCommissionDisplay == "5.00"
+        assert result.InitialMarginDisplay == "7,602.50"
+        assert result.ProductCurrency == "USD"
+        assert result.AccountCurrency == "USD"
+
+    @pytest.mark.asyncio
+    async def test_confirm_limit_order(self, order_execution_service, http_client_mock):
+        """Test confirmation of a limit order"""
+        # Mock response data
+        mock_response = {
+            "Route": "Intelligent",
+            "Duration": "Day",
+            "Account": "123456",
+            "SummaryMessage": "Buy 100 MSFT Limit @ 150.00 Day",
+            "EstimatedPrice": "150.00",
+            "EstimatedPriceDisplay": "150.00",
+            "EstimatedCommission": "5.00",
+            "EstimatedCommissionDisplay": "5.00",
+            "InitialMarginDisplay": "7,500.00",
+            "ProductCurrency": "USD",
+            "AccountCurrency": "USD",
+        }
+
+        # Configure mock
+        http_client_mock.post.return_value = mock_response
+
+        # Create request
+        request = OrderRequest(
+            AccountID="123456",
+            Symbol="MSFT",
+            Quantity="100",
+            OrderType=OrderType.LIMIT,
+            LimitPrice="150.00",
+            TradeAction=OrderSide.BUY,
+            TimeInForce=TimeInForce(Duration=OrderDuration.DAY),
+            Route="Intelligent",
+        )
+
+        # Call the method
+        result = await order_execution_service.confirm_order(request)
+
+        # Verify the API was called correctly
+        http_client_mock.post.assert_called_once_with(
+            "/v3/orderexecution/orderconfirm", request.model_dump(exclude_none=True)
+        )
+
+        # Verify the result
+        assert isinstance(result, OrderConfirmationResponse)
+        assert result.Route == "Intelligent"
+        assert result.Duration == "Day"
+        assert result.Account == "123456"
+        assert result.SummaryMessage == "Buy 100 MSFT Limit @ 150.00 Day"
+        assert result.EstimatedPrice == "150.00"
+        assert result.EstimatedPriceDisplay == "150.00"
+        assert result.EstimatedCommission == "5.00"
+        assert result.EstimatedCommissionDisplay == "5.00"
+        assert result.InitialMarginDisplay == "7,500.00"
+        assert result.ProductCurrency == "USD"
+        assert result.AccountCurrency == "USD"
+
+    @pytest.mark.asyncio
+    async def test_confirm_stop_order(self, order_execution_service, http_client_mock):
+        """Test confirmation of a stop market order"""
+        # Mock response data
+        mock_response = {
+            "Route": "Intelligent",
+            "Duration": "Day",
+            "Account": "123456",
+            "SummaryMessage": "Sell 100 MSFT Stop @ 155.00 Day",
+            "EstimatedPrice": "155.00",
+            "EstimatedPriceDisplay": "155.00",
+            "EstimatedCommission": "5.00",
+            "EstimatedCommissionDisplay": "5.00",
+            "InitialMarginDisplay": "0.00",
+            "ProductCurrency": "USD",
+            "AccountCurrency": "USD",
+        }
+
+        # Configure mock
+        http_client_mock.post.return_value = mock_response
+
+        # Create request
+        request = OrderRequest(
+            AccountID="123456",
+            Symbol="MSFT",
+            Quantity="100",
+            OrderType=OrderType.STOP_MARKET,
+            StopPrice="155.00",
+            TradeAction=OrderSide.SELL,
+            TimeInForce=TimeInForce(Duration=OrderDuration.DAY),
+            Route="Intelligent",
+        )
+
+        # Call the method
+        result = await order_execution_service.confirm_order(request)
+
+        # Verify the API was called correctly
+        http_client_mock.post.assert_called_once_with(
+            "/v3/orderexecution/orderconfirm", request.model_dump(exclude_none=True)
+        )
+
+        # Verify the result
+        assert isinstance(result, OrderConfirmationResponse)
+        assert result.Route == "Intelligent"
+        assert result.Duration == "Day"
+        assert result.Account == "123456"
+        assert result.SummaryMessage == "Sell 100 MSFT Stop @ 155.00 Day"
+        assert result.EstimatedPrice == "155.00"
+        assert result.EstimatedPriceDisplay == "155.00"
+        assert result.EstimatedCommission == "5.00"
+        assert result.EstimatedCommissionDisplay == "5.00"
+        assert result.InitialMarginDisplay == "0.00"
+        assert result.ProductCurrency == "USD"
+        assert result.AccountCurrency == "USD"
+
+    @pytest.mark.asyncio
+    async def test_confirm_order_validation_errors(self, order_execution_service, http_client_mock):
+        """Test validation errors when confirming an order"""
+        # Mock response with validation error
+        mock_response = {
+            "Route": "Intelligent",
+            "Duration": "Day",
+            "Account": "123456",
+            "SummaryMessage": "Invalid order: Quantity must be greater than 0",
+        }
+
+        # Configure mock
+        http_client_mock.post.return_value = mock_response
+
+        # Create request with invalid quantity
+        request = OrderRequest(
+            AccountID="123456",
+            Symbol="MSFT",
+            Quantity="-100",  # Invalid quantity
+            OrderType=OrderType.MARKET,
+            TradeAction=OrderSide.BUY,
+            TimeInForce=TimeInForce(Duration=OrderDuration.DAY),
+            Route="Intelligent",
+        )
+
+        # Call the method
+        result = await order_execution_service.confirm_order(request)
+
+        # Verify the API was called correctly
+        http_client_mock.post.assert_called_once_with(
+            "/v3/orderexecution/orderconfirm", request.model_dump(exclude_none=True)
+        )
+
+        # Verify the result
+        assert isinstance(result, OrderConfirmationResponse)
+        assert result.Route == "Intelligent"
+        assert result.Duration == "Day"
+        assert result.Account == "123456"
+        assert result.SummaryMessage == "Invalid order: Quantity must be greater than 0"
+        assert result.EstimatedPrice is None
+        assert result.EstimatedPriceDisplay is None
+        assert result.EstimatedCommission is None
+        assert result.EstimatedCommissionDisplay is None
+        assert result.InitialMarginDisplay is None
+
+    @pytest.mark.asyncio
+    async def test_confirm_order_network_error(self, order_execution_service, http_client_mock):
+        """Test network error handling when confirming an order"""
+        # Configure mock to raise an exception
+        http_client_mock.post.side_effect = Exception("Network error")
+
+        # Create request
+        request = OrderRequest(
+            AccountID="123456",
+            Symbol="MSFT",
+            Quantity="100",
+            OrderType=OrderType.MARKET,
+            TradeAction=OrderSide.BUY,
+            TimeInForce=TimeInForce(Duration=OrderDuration.DAY),
+            Route="Intelligent",
+        )
+
+        # Verify that the exception is propagated
+        with pytest.raises(Exception, match="Network error"):
+            await order_execution_service.confirm_order(request)
+
+        # Verify the API was called correctly
+        http_client_mock.post.assert_called_once_with(
+            "/v3/orderexecution/orderconfirm", request.model_dump(exclude_none=True)
+        )
+
+    @pytest.mark.asyncio
+    async def test_confirm_order_unauthorized(self, order_execution_service, http_client_mock):
+        """Test unauthorized error handling when confirming an order"""
+        # Configure mock to raise an unauthorized exception
+        http_client_mock.post.side_effect = Exception("Unauthorized")
+
+        # Create request
+        request = OrderRequest(
+            AccountID="123456",
+            Symbol="MSFT",
+            Quantity="100",
+            OrderType=OrderType.MARKET,
+            TradeAction=OrderSide.BUY,
+            TimeInForce=TimeInForce(Duration=OrderDuration.DAY),
+            Route="Intelligent",
+        )
+
+        # Verify that the exception is propagated
+        with pytest.raises(Exception, match="Unauthorized"):
+            await order_execution_service.confirm_order(request)
+
+        # Verify the API was called correctly
+        http_client_mock.post.assert_called_once_with(
+            "/v3/orderexecution/orderconfirm", request.model_dump(exclude_none=True)
+        )


### PR DESCRIPTION
# PR: Implement confirm_order method for OrderExecutionService

## Overview
This PR implements the `confirm_order` method in the OrderExecutionService class, allowing users to confirm order details including estimated price and commission information without actually placing the order.

## What was implemented
- `confirm_order` method in OrderExecutionService
- Comprehensive unit tests covering various order types
- Error handling for validation errors and API failures

## Implementation details

### Design Approach
The implementation follows the existing service design pattern with:
- Simple async method that posts to the TradeStation API endpoint
- Proper serialization of request parameters
- Response type mapping to Pydantic models
- Comprehensive error handling

### Files Changed
| File | Changes |
|------|---------|
| `src/services/OrderExecution/order_execution_service.py` | Added `confirm_order` method |
| `tests/services/OrderExecution/test_confirm_order.py` | Added unit tests |

### Architecture Flow
```mermaid
sequenceDiagram
    Client->>+OrderExecutionService: confirm_order(request)
    OrderExecutionService->>+HttpClient: post("/v3/orderexecution/orderconfirm", request)
    HttpClient->>+TradeStationAPI: HTTP POST Request
    TradeStationAPI-->>-HttpClient: JSON Response
    HttpClient-->>-OrderExecutionService: Parsed Response
    OrderExecutionService-->>-Client: OrderConfirmationResponse
```

## Testing
- Unit tests cover successful confirmation for market, limit, and stop orders
- Mock tests for error conditions (validation errors, API failure, unauthorized access)
- Verified that all existing tests continue to pass

## How to test the changes
```bash
# Run just the confirm_order tests
poetry run pytest tests/services/OrderExecution/test_confirm_order.py -v

# Run all tests to ensure backward compatibility
poetry run pytest
```

Closes #234
