### PR TITLE
Implement GetRoutes method for OrderExecutionService

### DIFF
--- a/src/services/OrderExecution/order_execution_service.py
+++ b/src/services/OrderExecution/order_execution_service.py
@@ -115,3 +115,41 @@ class OrderExecutionService:
             "/v3/orderexecution/ordergroupconfirm", request.model_dump(exclude_none=True)
         )
         return GroupOrderConfirmationResponse(**response)
+
+    async def get_routes(self) -> Routes:
+        """
+        Returns a list of valid routes that a client can specify when posting an order.
+        Routes are used to specify where an order should be sent for execution.
+
+        For Stocks and Options, if no route is specified in the order request,
+        the route will default to 'Intelligent'.
+
+        Returns:
+            A promise that resolves to an object containing an array of available routes
+
+        Raises:
+            Exception: Will raise an error if:
+                - The request is unauthorized (401)
+                - The request is forbidden (403)
+                - Bad request (400)
+
+        Example:
+            # Get available routes
+            routes = await service.get_routes()
+            print(routes.Routes)
+            # Example output:
+            # [
+            #   {
+            #     "Id": "AMEX",
+            #     "AssetTypes": ["STOCK"],
+            #     "Name": "AMEX"
+            #   },
+            #   {
+            #     "Id": "ARCA",
+            #     "AssetTypes": ["STOCK"],
+            #     "Name": "ARCX"
+            #   }
+            # ]
+        """
+        response = await self.http_client.get("/v3/orderexecution/routes")
+        return Routes(**response)

--- a/tests/services/OrderExecution/test_get_routes.py
+++ b/tests/services/OrderExecution/test_get_routes.py
@@ -1,0 +1,118 @@
+import pytest
+from src.ts_types.order_execution import Routes, Route
+
+
+class TestGetRoutes:
+    """Tests for the get_routes method in OrderExecutionService"""
+
+    @pytest.mark.asyncio
+    async def test_get_routes_success(self, order_execution_service, http_client_mock):
+        """Test successful retrieval of routes"""
+        # Mock response data
+        mock_response = {
+            "Routes": [
+                {"Id": "AMEX", "AssetTypes": ["STOCK"], "Name": "AMEX"},
+                {"Id": "ARCA", "AssetTypes": ["STOCK"], "Name": "ARCX"},
+                {"Id": "Intelligent", "AssetTypes": ["STOCK", "OPTION"], "Name": "Intelligent"},
+            ]
+        }
+
+        # Configure mock
+        http_client_mock.get.return_value = mock_response
+
+        # Call the method
+        result = await order_execution_service.get_routes()
+
+        # Verify the API was called correctly
+        http_client_mock.get.assert_called_once_with("/v3/orderexecution/routes")
+
+        # Verify the result
+        assert isinstance(result, Routes)
+        assert len(result.Routes) == 3
+
+        # Check first route
+        assert isinstance(result.Routes[0], Route)
+        assert result.Routes[0].Id == "AMEX"
+        assert result.Routes[0].AssetTypes == ["STOCK"]
+        assert result.Routes[0].Name == "AMEX"
+
+        # Check second route
+        assert result.Routes[1].Id == "ARCA"
+        assert result.Routes[1].AssetTypes == ["STOCK"]
+        assert result.Routes[1].Name == "ARCX"
+
+        # Check third route
+        assert result.Routes[2].Id == "Intelligent"
+        assert result.Routes[2].AssetTypes == ["STOCK", "OPTION"]
+        assert result.Routes[2].Name == "Intelligent"
+
+    @pytest.mark.asyncio
+    async def test_get_routes_empty(self, order_execution_service, http_client_mock):
+        """Test getting an empty list of routes"""
+        # Mock response data with empty routes array
+        mock_response = {"Routes": []}
+
+        # Configure mock
+        http_client_mock.get.return_value = mock_response
+
+        # Call the method
+        result = await order_execution_service.get_routes()
+
+        # Verify the API was called correctly
+        http_client_mock.get.assert_called_once_with("/v3/orderexecution/routes")
+
+        # Verify the result
+        assert isinstance(result, Routes)
+        assert len(result.Routes) == 0
+
+    @pytest.mark.asyncio
+    async def test_get_routes_network_error(self, order_execution_service, http_client_mock):
+        """Test network error handling when getting routes"""
+        # Configure mock to raise exception
+        http_client_mock.get.side_effect = Exception("Network error")
+
+        # Verify the exception is propagated
+        with pytest.raises(Exception, match="Network error"):
+            await order_execution_service.get_routes()
+
+        # Verify the API was called correctly
+        http_client_mock.get.assert_called_once_with("/v3/orderexecution/routes")
+
+    @pytest.mark.asyncio
+    async def test_get_routes_unauthorized(self, order_execution_service, http_client_mock):
+        """Test unauthorized error handling when getting routes"""
+        # Configure mock to raise unauthorized exception
+        http_client_mock.get.side_effect = Exception("Unauthorized")
+
+        # Verify the exception is propagated
+        with pytest.raises(Exception, match="Unauthorized"):
+            await order_execution_service.get_routes()
+
+        # Verify the API was called correctly
+        http_client_mock.get.assert_called_once_with("/v3/orderexecution/routes")
+
+    @pytest.mark.asyncio
+    async def test_get_routes_forbidden(self, order_execution_service, http_client_mock):
+        """Test forbidden error handling when getting routes"""
+        # Configure mock to raise forbidden exception
+        http_client_mock.get.side_effect = Exception("Forbidden")
+
+        # Verify the exception is propagated
+        with pytest.raises(Exception, match="Forbidden"):
+            await order_execution_service.get_routes()
+
+        # Verify the API was called correctly
+        http_client_mock.get.assert_called_once_with("/v3/orderexecution/routes")
+
+    @pytest.mark.asyncio
+    async def test_get_routes_bad_request(self, order_execution_service, http_client_mock):
+        """Test bad request error handling when getting routes"""
+        # Configure mock to raise bad request exception
+        http_client_mock.get.side_effect = Exception("Bad request")
+
+        # Verify the exception is propagated
+        with pytest.raises(Exception, match="Bad request"):
+            await order_execution_service.get_routes()
+
+        # Verify the API was called correctly
+        http_client_mock.get.assert_called_once_with("/v3/orderexecution/routes")


### PR DESCRIPTION
# PR: Implement GetRoutes method for OrderExecutionService

## Overview
This PR implements the `get_routes` method in the OrderExecutionService class, allowing users to fetch available routes for order execution.

## What was implemented
- `get_routes` method in OrderExecutionService
- Comprehensive test suite for get_routes method
- Full type safety and error handling

## Implementation details

### Design Approach
The implementation follows the established patterns within the codebase:
- Uses the HttpClient for API requests
- Returns strongly typed responses using Pydantic models
- Comprehensive error handling to match the TypeScript implementation
- Tests that cover both success and error cases

### Files Changed
| File | Changes |
|------|---------|
| `src/services/OrderExecution/order_execution_service.py` | Added `get_routes` method |
| `tests/services/OrderExecution/test_get_routes.py` | Added tests for the `get_routes` method |

### Architecture Flow
```mermaid
sequenceDiagram
    Client->>+OrderExecutionService: get_routes()
    OrderExecutionService->>+HttpClient: get('/v3/orderexecution/routes')
    HttpClient->>+TradeStationAPI: HTTP GET Request
    TradeStationAPI-->>-HttpClient: JSON Response
    HttpClient-->>-OrderExecutionService: Parsed JSON
    OrderExecutionService->>OrderExecutionService: Convert to Routes model
    OrderExecutionService-->>-Client: Routes object
```

## Testing
- Unit tests cover successful API responses
- Tests include both populated and empty response scenarios
- Error handling tests cover:
  - Network errors
  - Unauthorized (401) responses
  - Forbidden (403) responses
  - Bad request (400) responses

## How to test the changes
```bash
# Run the specific tests for get_routes
poetry run pytest tests/services/OrderExecution/test_get_routes.py -v

# Run all tests to ensure nothing was broken
poetry run pytest
```

Manual testing can be done with:
```python
from tradestation import TradeStation

ts = TradeStation()
routes = await ts.order_execution.get_routes()
print(routes)
```

Closes #237 