### PR TITLE
Implement GetActivationTriggers for issue #242

### DIFF
--- a/src/services/OrderExecution/order_execution_service.py
+++ b/src/services/OrderExecution/order_execution_service.py
@@ -211,3 +211,22 @@ class OrderExecutionService:
         """
         response = await self.http_client.get("/v3/orderexecution/routes")
         return Routes(**response)
+
+    async def get_activation_triggers(self) -> ActivationTriggers:
+        """
+        Gets a list of activation triggers that can be used when placing orders.
+
+        Returns:
+            A promise that resolves to an object containing an array of activation triggers
+
+        Raises:
+            Exception: Will raise an error if:
+                - The request is unauthorized (401)
+                - The request is forbidden (403)
+                - Bad request (400)
+                - Rate limit is exceeded (429)
+                - Service is unavailable (503)
+                - Gateway timeout (504)
+        """
+        response = await self.http_client.get("/v3/orderexecution/activationtriggers")
+        return ActivationTriggers(**response)

--- a/tests/services/OrderExecution/test_get_activation_triggers.py
+++ b/tests/services/OrderExecution/test_get_activation_triggers.py
@@ -1,0 +1,171 @@
+import pytest
+from src.ts_types.order_execution import ActivationTriggers, ActivationTrigger
+
+
+class TestGetActivationTriggers:
+    """Tests for the get_activation_triggers method in OrderExecutionService"""
+
+    @pytest.mark.asyncio
+    async def test_get_activation_triggers_success(self, order_execution_service, http_client_mock):
+        """Test successful retrieval of activation triggers"""
+        # Mock response data
+        mock_response = {
+            "ActivationTriggers": [
+                {"Key": "Ask", "Name": "Ask", "Description": "Last ask price for the symbol"},
+                {"Key": "Bid", "Name": "Bid", "Description": "Last bid price for the symbol"},
+                {"Key": "Last", "Name": "Last", "Description": "Last trade price for the symbol"},
+            ]
+        }
+
+        # Configure mock
+        http_client_mock.get.return_value = mock_response
+
+        # Call the method
+        result = await order_execution_service.get_activation_triggers()
+
+        # Verify the API was called correctly
+        http_client_mock.get.assert_called_once_with("/v3/orderexecution/activationtriggers")
+
+        # Verify the result
+        assert isinstance(result, ActivationTriggers)
+        assert len(result.ActivationTriggers) == 3
+
+        # Check first trigger
+        assert isinstance(result.ActivationTriggers[0], ActivationTrigger)
+        assert result.ActivationTriggers[0].Key == "Ask"
+        assert result.ActivationTriggers[0].Name == "Ask"
+        assert result.ActivationTriggers[0].Description == "Last ask price for the symbol"
+
+        # Check second trigger
+        assert result.ActivationTriggers[1].Key == "Bid"
+        assert result.ActivationTriggers[1].Name == "Bid"
+        assert result.ActivationTriggers[1].Description == "Last bid price for the symbol"
+
+        # Check third trigger
+        assert result.ActivationTriggers[2].Key == "Last"
+        assert result.ActivationTriggers[2].Name == "Last"
+        assert result.ActivationTriggers[2].Description == "Last trade price for the symbol"
+
+    @pytest.mark.asyncio
+    async def test_get_activation_triggers_empty(self, order_execution_service, http_client_mock):
+        """Test getting an empty list of activation triggers"""
+        # Mock response data with empty triggers array
+        mock_response = {"ActivationTriggers": []}
+
+        # Configure mock
+        http_client_mock.get.return_value = mock_response
+
+        # Call the method
+        result = await order_execution_service.get_activation_triggers()
+
+        # Verify the API was called correctly
+        http_client_mock.get.assert_called_once_with("/v3/orderexecution/activationtriggers")
+
+        # Verify the result
+        assert isinstance(result, ActivationTriggers)
+        assert len(result.ActivationTriggers) == 0
+
+    @pytest.mark.asyncio
+    async def test_get_activation_triggers_network_error(
+        self, order_execution_service, http_client_mock
+    ):
+        """Test network error handling when getting activation triggers"""
+        # Configure mock to raise exception
+        http_client_mock.get.side_effect = Exception("Network error")
+
+        # Verify the exception is propagated
+        with pytest.raises(Exception, match="Network error"):
+            await order_execution_service.get_activation_triggers()
+
+        # Verify the API was called correctly
+        http_client_mock.get.assert_called_once_with("/v3/orderexecution/activationtriggers")
+
+    @pytest.mark.asyncio
+    async def test_get_activation_triggers_unauthorized(
+        self, order_execution_service, http_client_mock
+    ):
+        """Test unauthorized error handling when getting activation triggers"""
+        # Configure mock to raise unauthorized exception
+        http_client_mock.get.side_effect = Exception("Unauthorized")
+
+        # Verify the exception is propagated
+        with pytest.raises(Exception, match="Unauthorized"):
+            await order_execution_service.get_activation_triggers()
+
+        # Verify the API was called correctly
+        http_client_mock.get.assert_called_once_with("/v3/orderexecution/activationtriggers")
+
+    @pytest.mark.asyncio
+    async def test_get_activation_triggers_forbidden(
+        self, order_execution_service, http_client_mock
+    ):
+        """Test forbidden error handling when getting activation triggers"""
+        # Configure mock to raise forbidden exception
+        http_client_mock.get.side_effect = Exception("Forbidden")
+
+        # Verify the exception is propagated
+        with pytest.raises(Exception, match="Forbidden"):
+            await order_execution_service.get_activation_triggers()
+
+        # Verify the API was called correctly
+        http_client_mock.get.assert_called_once_with("/v3/orderexecution/activationtriggers")
+
+    @pytest.mark.asyncio
+    async def test_get_activation_triggers_bad_request(
+        self, order_execution_service, http_client_mock
+    ):
+        """Test bad request error handling when getting activation triggers"""
+        # Configure mock to raise bad request exception
+        http_client_mock.get.side_effect = Exception("Bad request")
+
+        # Verify the exception is propagated
+        with pytest.raises(Exception, match="Bad request"):
+            await order_execution_service.get_activation_triggers()
+
+        # Verify the API was called correctly
+        http_client_mock.get.assert_called_once_with("/v3/orderexecution/activationtriggers")
+
+    @pytest.mark.asyncio
+    async def test_get_activation_triggers_rate_limit_exceeded(
+        self, order_execution_service, http_client_mock
+    ):
+        """Test rate limit exceeded error handling when getting activation triggers"""
+        # Configure mock to raise rate limit exceeded exception
+        http_client_mock.get.side_effect = Exception("Rate limit exceeded")
+
+        # Verify the exception is propagated
+        with pytest.raises(Exception, match="Rate limit exceeded"):
+            await order_execution_service.get_activation_triggers()
+
+        # Verify the API was called correctly
+        http_client_mock.get.assert_called_once_with("/v3/orderexecution/activationtriggers")
+
+    @pytest.mark.asyncio
+    async def test_get_activation_triggers_service_unavailable(
+        self, order_execution_service, http_client_mock
+    ):
+        """Test service unavailable error handling when getting activation triggers"""
+        # Configure mock to raise service unavailable exception
+        http_client_mock.get.side_effect = Exception("Service unavailable")
+
+        # Verify the exception is propagated
+        with pytest.raises(Exception, match="Service unavailable"):
+            await order_execution_service.get_activation_triggers()
+
+        # Verify the API was called correctly
+        http_client_mock.get.assert_called_once_with("/v3/orderexecution/activationtriggers")
+
+    @pytest.mark.asyncio
+    async def test_get_activation_triggers_gateway_timeout(
+        self, order_execution_service, http_client_mock
+    ):
+        """Test gateway timeout error handling when getting activation triggers"""
+        # Configure mock to raise gateway timeout exception
+        http_client_mock.get.side_effect = Exception("Gateway timeout")
+
+        # Verify the exception is propagated
+        with pytest.raises(Exception, match="Gateway timeout"):
+            await order_execution_service.get_activation_triggers()
+
+        # Verify the API was called correctly
+        http_client_mock.get.assert_called_once_with("/v3/orderexecution/activationtriggers")


### PR DESCRIPTION
# PR: Implement GetActivationTriggers for Order Execution Service

## Overview
This PR implements the `get_activation_triggers` method in the OrderExecutionService class, allowing users to fetch available activation triggers for conditional orders.

## What was implemented
- `get_activation_triggers` method in OrderExecutionService
- Comprehensive unit tests for the method with coverage for success and error cases

## Implementation details

### Design Approach
The implementation follows the established repository pattern in the project with:
- Public API method in the service class
- Response parsing using Pydantic models
- Error propagation matching other service methods
- Comprehensive test coverage

### Files Changed
| File | Changes |
|------|----------|
| `src/services/OrderExecution/order_execution_service.py` | Added `get_activation_triggers` method |
| `tests/services/OrderExecution/test_get_activation_triggers.py` | Added unit tests |

### Architecture Flow
```mermaid
sequenceDiagram
    Client->>+OrderExecutionService: get_activation_triggers()
    OrderExecutionService->>+HttpClient: get(\"/v3/orderexecution/activationtriggers\")
    HttpClient->>+TradeStationAPI: HTTP GET Request
    TradeStationAPI-->>-HttpClient: JSON Response
    HttpClient-->>-OrderExecutionService: Parsed JSON
    OrderExecutionService->>OrderExecutionService: Transform to ActivationTriggers
    OrderExecutionService-->>-Client: ActivationTriggers object
```

## Testing
- Unit tests cover successful API responses
- Mock tests for error conditions (network error, auth issues, etc.)
- Edge case tested: empty activation triggers array

## How to test the changes
```bash
# Run specific tests for this feature
poetry run pytest tests/services/OrderExecution/test_get_activation_triggers.py -v

# Run all tests to verify nothing was broken
poetry run pytest
```

Closes #242
