### PR TITLE
Implement Get Option SpreadTypes example for issue #251

### DIFF
--- a/examples/MarketData/get_option_spreadtypes.py
+++ b/examples/MarketData/get_option_spreadtypes.py
@@ -30,9 +30,27 @@ async def main():
         # Check if the response contains spread types
         if spread_types:
             print("Successfully retrieved option spread types:")
-            # Iterate through the list of spread types and print each one
-            for spread_type in spread_types:
-                print(f"- {spread_type}")
+            # Iterate through the list of SpreadType objects and print each name
+            # Assuming spread_types is the list returned by the API client
+            try:
+                # Access the list directly via the attribute name if it's an object
+                # (Based on the last successful run output: SpreadTypes=[...])
+                actual_list = spread_types.SpreadTypes
+                if isinstance(actual_list, list):
+                    for spread_type in actual_list:
+                        if hasattr(spread_type, "Name"):
+                            print(f"- {spread_type.Name}")
+                        else:
+                            print(f"- {spread_type}")  # Fallback
+                else:
+                    print(f"Expected a list for SpreadTypes, but got: {type(actual_list)}")
+            except AttributeError:
+                # Fallback if spread_types doesn't have a SpreadTypes attribute
+                print(
+                    f"Unexpected response structure. Expected attribute 'SpreadTypes': {spread_types}"
+                )
+            except Exception as inner_e:
+                print(f"An error occurred while processing spread types: {inner_e}")
         else:
             # Handle cases where the API returns an empty list or null response
             print("No option spread types were returned.")


### PR DESCRIPTION
# PR: Implement Get Option SpreadTypes Example (#251)

## Overview
This PR implements the example script for fetching option spread types as required by issue #251. It demonstrates how to use the `TradeStationClient` to call the `get_option_spread_types` method within the MarketData service.

## What was implemented
- Created `examples/MarketData/get_option_spreadtypes.py`
- Fetches and prints available option spread types using `TradeStationClient`.
- Includes basic error handling.
- Added necessary imports and environment variable loading (`dotenv`).
- Added client session cleanup using `finally` block.

## Implementation details

### Design Approach
The example follows a simple asynchronous script pattern:
1. Load environment variables.
2. Instantiate `TradeStationClient`.
3. Call the target API method (`get_option_spread_types`).
4. Print the results or handle errors.
5. Close the client session in a `finally` block.

### Files Changed
| File                                                | Changes                                                                  |
|-----------------------------------------------------|--------------------------------------------------------------------------|
| `examples/MarketData/get_option_spreadtypes.py` | New file created with the example implementation.                       |
| `examples/MarketData/get_option_spreadtypes.py` | Corrected `TradeStation` import to `src.client.tradestation_client.TradeStationClient` |
| `examples/MarketData/get_option_spreadtypes.py` | Added `await ts.close()` in a `finally` block for proper session cleanup. |

### Architecture Flow
```mermaid
sequenceDiagram
    participant User
    participant Script as get_option_spreadtypes.py
    participant Client as TradeStationClient
    participant API as TradeStation API

    User->>+Script: Runs script
    Script->>+Client: Instantiate TradeStationClient()
    Script->>+Client: await get_option_spread_types()
    Client->>+API: GET /v3/marketdata/options/spreadtypes
    API-->>-Client: JSON Response (SpreadTypes List)
    Client-->>-Script: Returns list of SpreadType objects
    Script->>Script: Prints spread types
    Script->>+Client: await close()
    Client-->>-Script: Session closed
    Script-->>-User: Prints output / Exits
```

## Testing
- No automated tests were required for this example as per issue #251.
- Manual testing was performed by running the script.

## How to test the changes
1. Ensure you have a `.env` file in the project root with valid `TRADESTATION_CLIENT_ID`, `TRADESTATION_CLIENT_SECRET`, and `TRADESTATION_REFRESH_TOKEN`.
2. Run the following command from the project root directory:
   ```bash
   poetry run python examples/MarketData/get_option_spreadtypes.py
   ```
3. Verify the script prints the list of option spread types without errors and exits cleanly.

## Knowledge Base Updates
- No updates made to `CONTINUOUS-SELF-LEARNING.md` for this task.

Closes #251
